### PR TITLE
Make secrets compatible with github pushes

### DIFF
--- a/netbox_webhook_receiver/views/views.py
+++ b/netbox_webhook_receiver/views/views.py
@@ -95,7 +95,8 @@ def authenticate_request(request, receiver) -> bool:
         import hashlib
         import hmac
 
-        hmac_header = request.headers.get(receiver.auth_header, "")
+        hmac_header = request.headers.get(
+            receiver.auth_header, "").removeprefix("sha256=")
         hash_algorithm = receiver.hash_algorithm or "sha512"
 
         # Calculate hexadecimal HMAC digest


### PR DESCRIPTION
Github prefixes the secret value with `sha256=` in webhooks, this PR strips that prefix from the secret before comparison to make it compatible.