### PR TITLE
Switch to SyncDataSourceJob

### DIFF
--- a/netbox_webhook_receiver/views/views.py
+++ b/netbox_webhook_receiver/views/views.py
@@ -13,6 +13,7 @@ from django.views.decorators.csrf import csrf_exempt
 from django.views.decorators.http import require_POST
 from netbox_webhook_receiver.models import WebhookMessage, WebhookReceiver
 from secrets import compare_digest
+from core.jobs import SyncDataSourceJob
 from users.models import User
 
 logger = logging.getLogger(__name__)
@@ -75,7 +76,8 @@ in {receiver.auth_header} header.",
 
 @atomic
 def process_webhook_sync_datasource(receiver):
-    receiver.datasource.enqueue_sync_job(request=DefaultUserRequest())
+    SyncDataSourceJob.enqueue(
+        instance=receiver.datasource, user=DefaultUserRequest().user)
 
     return f"Synchronizing Data Source: {receiver.datasource.name}"
 


### PR DESCRIPTION
datasource.enqueue_sync_job was [removed](https://github.com/netbox-community/netbox/pull/16927/files#diff-0ac4b6d38e3cdbc3b7c1b54b5911a22e9c8db5cfae8c10645884aa4d0f482eddL39), so this no longer works on the latest netbox.

This PR uses the new SyncDataSourceJob.enqueue api.